### PR TITLE
Introduce TOML version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,8 @@ dependencies {
     implementation xplibs.node
     implementation xplibs.context
     implementation xplibs.cluster
-    implementation "com.enonic.lib:lib-cache:3.0.0-SNAPSHOT"
-    implementation "com.enonic.lib:lib-http-client:4.0.0-SNAPSHOT"
+    implementation libs.lib.cache
+    implementation libs.lib.http.client
 }
 
 node {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,7 @@
+[versions]
+cache = "3.0.0-SNAPSHOT"
+http-client = "4.0.0-SNAPSHOT"
+
+[libraries]
+lib-cache = { module = "com.enonic.lib:lib-cache", version.ref = "cache" }
+lib-http-client = { module = "com.enonic.lib:lib-http-client", version.ref = "http-client" }


### PR DESCRIPTION
## Summary

Move inline dependency versions from `build.gradle` into a new
`gradle/libs.versions.toml`. Resolved dependency tree is identical
pre/post migration; no version bumps.

Conventions adopted (matching neighbouring repos like `app-features` /
`lib-explorer`):

- Alphabetical sort within `[versions]` and `[libraries]`.
- Lowercase, hyphen-separated keys (e.g. `http-client`, not `httpClient`).
- `xpVersion` stays in `gradle.properties`; `xplibs.*` accessors are
  unchanged (those are owned by the XP gradle settings plugin).

## Catalog

```toml
[versions]
cache = "3.0.0-SNAPSHOT"
http-client = "4.0.0-SNAPSHOT"

[libraries]
lib-cache = { module = "com.enonic.lib:lib-cache", version.ref = "cache" }
lib-http-client = { module = "com.enonic.lib:lib-http-client", version.ref = "http-client" }
```

## Test plan

- [x] `./gradlew build --refresh-dependencies` green locally.
- [x] `./gradlew dependencies --configuration runtimeClasspath` diff
  against pre-migration HEAD is empty (only the build-time line differs).

<sub>*Drafted with AI assistance*</sub>